### PR TITLE
Add contact page and return links to policy pages

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -593,6 +593,7 @@ function ProfileMenu({ householdId, entitlements, household }: { householdId: st
               <button className="w-full text-left px-3 py-2 hover:bg-gray-50" onClick={upgrade}>Upgrade to Premium</button>
             )}
             <a className="block px-3 py-2 hover:bg-gray-50" href="/feedback">Send feedback</a>
+            <a className="block px-3 py-2 hover:bg-gray-50" href="/contact">Contact us</a>
             <a className="block px-3 py-2 hover:bg-gray-50" href="/terms" target="_blank" rel="noreferrer">Terms</a>
             <a className="block px-3 py-2 hover:bg-gray-50" href="/privacy" target="_blank" rel="noreferrer">Privacy</a>
           </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,13 @@
+export default function ContactPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12 text-gray-800">
+      <h1 className="text-3xl font-semibold mb-4">Contact Us</h1>
+      <p className="text-sm mb-3">
+        Have questions or need support? Reach out to us at
+        <a href="mailto:support@prosper.com" className="underline"> support@prosper.com</a>.
+      </p>
+      <p className="text-sm">We look forward to hearing from you.</p>
+    </main>
+  );
+}
+

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,11 @@
+import Link from "next/link";
+
 export default function PrivacyPage() {
   return (
     <main className="max-w-3xl mx-auto px-4 py-12 text-gray-800">
+      <Link href="/" className="text-sm text-blue-600 hover:underline mb-4 block">
+        &larr; Return
+      </Link>
       <h1 className="text-3xl font-semibold mb-4">Privacy Policy</h1>
       <p className="text-sm mb-3">We respect your privacy. This Policy describes how Prosper collects, uses, and protects your information.</p>
       <p className="text-sm mb-3">We use your data to personalize your experience and compute your KPIs and plan. We do not sell your data. You can request deletion of your information at any time.</p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,11 @@
+import Link from "next/link";
+
 export default function TermsPage() {
   return (
     <main className="max-w-3xl mx-auto px-4 py-12 text-gray-800">
+      <Link href="/" className="text-sm text-blue-600 hover:underline mb-4 block">
+        &larr; Return
+      </Link>
       <h1 className="text-3xl font-semibold mb-4">Terms of Use</h1>
       <p className="text-sm mb-3">These Terms govern your use of Prosper. By using the service, you agree to these Terms.</p>
       <p className="text-sm mb-3">Prosper provides general, educational information and planning tools. Prosper is not a financial adviser and does not provide financial advice. Consider your objectives and circumstances, and seek professional advice where appropriate.</p>


### PR DESCRIPTION
## Summary
- add dedicated contact page and link from user dropdown
- provide return navigation on terms and privacy pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and no-img-element across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b686cc02fc8326abffd46e9b87cfa4