### PR TITLE
feat: apply Prosper branding palette

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -359,19 +359,19 @@ function App() {
   }, []);
 
   return (
-    <div className="text-base flex flex-col h-screen bg-gray-100 text-gray-800">
+    <div className="text-base flex flex-col h-screen bg-prosper-neutral-background text-prosper-neutral-dark-ink">
       {/* Header */}
       <div className="p-5 text-lg font-semibold flex justify-between items-center max-w-7xl mx-auto w-full relative">
         <Link href="/home" className="flex items-center">
           <Image src="2D76K394f.eps.svg" alt="Prosper Logo" width={20} height={20} className="mr-2" />
-          <span>Prosper AI <span className="text-gray-400">your personal wealth coach</span></span>
+          <span>Prosper AI <span className="text-prosper-neutral-text">your personal wealth coach</span></span>
         </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
-          <Link href="/home" className="text-gray-700 hover:text-gray-900">Home</Link>
-          <Link href="/pricing" className="text-gray-700 hover:text-gray-900">Pricing</Link>
-          <Link href="/feedback" className="text-gray-700 hover:text-gray-900">Feedback</Link>
-          <a href="#" onClick={(e) => { e.preventDefault(); setActiveTab('chat'); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="text-gray-700 hover:text-gray-900">Chat</a>
-          <a href="#" onClick={(e) => { e.preventDefault(); setActiveTab('dashboard'); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="text-gray-700 hover:text-gray-900">Dashboard</a>
+          <Link href="/home" className="text-prosper-neutral-text hover:text-prosper-neutral-dark-ink">Home</Link>
+          <Link href="/pricing" className="text-prosper-neutral-text hover:text-prosper-neutral-dark-ink">Pricing</Link>
+          <Link href="/feedback" className="text-prosper-neutral-text hover:text-prosper-neutral-dark-ink">Feedback</Link>
+          <a href="#" onClick={(e) => { e.preventDefault(); setActiveTab('chat'); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="text-prosper-neutral-text hover:text-prosper-neutral-dark-ink">Chat</a>
+          <a href="#" onClick={(e) => { e.preventDefault(); setActiveTab('dashboard'); window.scrollTo({ top: 0, behavior: 'smooth' }); }} className="text-prosper-neutral-text hover:text-prosper-neutral-dark-ink">Dashboard</a>
         </nav>
         <ProfileMenu
           householdId={householdId}
@@ -450,17 +450,17 @@ function App() {
         </div>
 
         {/* Bottom mobile tab bar */}
-        <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white border-t shadow-sm z-40">
+        <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-prosper-neutral-background border-t border-prosper-neutral-divider shadow-sm z-40">
           <div className="max-w-7xl mx-auto px-2">
             <div className="flex justify-around py-2">
               <button
-                className={`px-4 py-2 rounded-md text-sm ${activeTab === 'chat' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-800'}`}
+                className={`px-4 py-2 rounded-md text-sm ${activeTab === 'chat' ? 'bg-prosper-green-dark text-white' : 'bg-prosper-neutral-background text-prosper-neutral-dark-ink'}`}
                 onClick={() => setActiveTab('chat')}
               >
                 Chat
               </button>
               <button
-                className={`px-4 py-2 rounded-md text-sm ${activeTab === 'dashboard' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-800'}`}
+                className={`px-4 py-2 rounded-md text-sm ${activeTab === 'dashboard' ? 'bg-prosper-green-dark text-white' : 'bg-prosper-neutral-background text-prosper-neutral-dark-ink'}`}
                 onClick={() => setActiveTab('dashboard')}
               >
                 Dashboard
@@ -472,23 +472,23 @@ function App() {
       {/* Terms & Privacy consent bar */}
       {!hasAccepted && (
         <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg border shadow-xl w-full max-w-lg p-5">
+          <div className="bg-prosper-neutral-background rounded-lg border border-prosper-neutral-divider shadow-xl w-full max-w-lg p-5">
             <div className="flex items-start gap-3">
-              <div className="h-6 w-6 rounded-full bg-yellow-100 border border-yellow-300 flex items-center justify-center shrink-0" aria-hidden="true">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M12 8v5" stroke="#a16207" strokeWidth="2"/><circle cx="12" cy="17" r="1" fill="#a16207"/></svg>
+              <div className="h-6 w-6 rounded-full bg-prosper-accent-gold/20 border border-prosper-accent-gold flex items-center justify-center shrink-0" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M12 8v5" stroke="#d9b648" strokeWidth="2"/><circle cx="12" cy="17" r="1" fill="#d9b648"/></svg>
               </div>
               <div className="flex-1">
-                <div className="text-base font-semibold text-gray-900">Please accept our Terms to continue</div>
-                <div className="text-sm text-gray-700 mt-1">To use Prosper, you need to accept our Terms and Privacy Policy.</div>
-                <div className="text-sm text-gray-600 mt-2">
+                <div className="text-base font-semibold text-prosper-neutral-dark-ink">Please accept our Terms to continue</div>
+                <div className="text-sm text-prosper-neutral-text mt-1">To use Prosper, you need to accept our Terms and Privacy Policy.</div>
+                <div className="text-sm text-prosper-neutral-text mt-2">
                   By continuing you agree to our <a href="/terms" target="_blank" className="underline">Terms</a> and <a href="/privacy" target="_blank" className="underline">Privacy Policy</a>.
                 </div>
                 <div className="mt-3 flex items-center justify-end gap-2">
-                  <a className="px-3 py-1.5 rounded-md border bg-white hover:bg-gray-50 text-sm" href="/terms" target="_blank" rel="noreferrer">View Terms</a>
-                  <a className="px-3 py-1.5 rounded-md border bg-white hover:bg-gray-50 text-sm" href="/privacy" target="_blank" rel="noreferrer">View Privacy</a>
+                  <a className="px-3 py-1.5 rounded-md border border-prosper-neutral-divider bg-white hover:bg-prosper-neutral-background text-sm" href="/terms" target="_blank" rel="noreferrer">View Terms</a>
+                  <a className="px-3 py-1.5 rounded-md border border-prosper-neutral-divider bg-white hover:bg-prosper-neutral-background text-sm" href="/privacy" target="_blank" rel="noreferrer">View Privacy</a>
                   <button
                     type="button"
-                    className="px-3 py-1.5 rounded-md border bg-gray-900 text-white hover:bg-gray-800 text-sm"
+                    className="px-3 py-1.5 rounded-md border bg-prosper-green-main text-white hover:bg-prosper-green-dark text-sm"
                     onClick={() => {
                       try { localStorage.setItem('pp_terms_v1_accepted', '1'); } catch {}
                       setHasAccepted(true);
@@ -569,7 +569,7 @@ function ProfileMenu({ householdId, entitlements, household }: { householdId: st
     <div id="pp_profile_menu" className="relative">
       <button
         onClick={(e) => { e.stopPropagation(); setOpen(v => !v); }}
-        className="h-9 w-9 rounded-full border bg-gray-900 text-white flex items-center justify-center hover:opacity-90"
+        className="h-9 w-9 rounded-full border border-prosper-neutral-divider bg-prosper-green-dark text-white flex items-center justify-center hover:opacity-90"
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={fullName ? `Profile: ${fullName}` : (email ? `Profile: ${email}` : 'Profile')}
@@ -578,43 +578,43 @@ function ProfileMenu({ householdId, entitlements, household }: { householdId: st
         <span className="text-[11px] font-semibold">{initials}</span>
       </button>
       {open && (
-        <div role="menu" className="absolute right-0 mt-2 w-64 bg-white border rounded-lg shadow-lg z-50">
-          <div className="px-3 py-2 border-b">
-            <div className="text-sm font-medium text-gray-900 truncate">{fullName || 'Guest'}</div>
-            <div className="text-xs text-gray-600 truncate">{email || 'No email'}</div>
-            <div className="text-[11px] text-gray-500 mt-1">Plan: <b className={plan === 'premium' ? 'text-emerald-600' : 'text-gray-700'}>{plan}</b></div>
+        <div role="menu" className="absolute right-0 mt-2 w-64 bg-prosper-neutral-background border border-prosper-neutral-divider rounded-lg shadow-lg z-50">
+          <div className="px-3 py-2 border-b border-prosper-neutral-divider">
+            <div className="text-sm font-medium text-prosper-neutral-dark-ink truncate">{fullName || 'Guest'}</div>
+            <div className="text-xs text-prosper-neutral-text truncate">{email || 'No email'}</div>
+            <div className="text-[11px] text-prosper-neutral-text mt-1">Plan: <b className={plan === 'premium' ? 'text-prosper-green-main' : 'text-prosper-neutral-dark-ink'}>{plan}</b></div>
           </div>
           <div className="py-1 text-sm">
-            <button className="w-full text-left px-3 py-2 hover:bg-gray-50" onClick={() => { setShowEdit(true); setOpen(false); }}>Edit profile</button>
-            <button className="w-full text-left px-3 py-2 hover:bg-gray-50" onClick={openUserData}>Review data</button>
+            <button className="w-full text-left px-3 py-2 hover:bg-prosper-neutral-background" onClick={() => { setShowEdit(true); setOpen(false); }}>Edit profile</button>
+            <button className="w-full text-left px-3 py-2 hover:bg-prosper-neutral-background" onClick={openUserData}>Review data</button>
             {plan === 'premium' ? (
-              <button className="w-full text-left px-3 py-2 hover:bg-gray-50" onClick={managePlan}>Manage plan</button>
+                <button className="w-full text-left px-3 py-2 hover:bg-prosper-neutral-background" onClick={managePlan}>Manage plan</button>
             ) : (
-              <button className="w-full text-left px-3 py-2 hover:bg-gray-50" onClick={upgrade}>Upgrade to Premium</button>
+                <button className="w-full text-left px-3 py-2 hover:bg-prosper-neutral-background" onClick={upgrade}>Upgrade to Premium</button>
             )}
-            <a className="block px-3 py-2 hover:bg-gray-50" href="/feedback">Send feedback</a>
-            <a className="block px-3 py-2 hover:bg-gray-50" href="/contact">Contact us</a>
-            <a className="block px-3 py-2 hover:bg-gray-50" href="/terms" target="_blank" rel="noreferrer">Terms</a>
-            <a className="block px-3 py-2 hover:bg-gray-50" href="/privacy" target="_blank" rel="noreferrer">Privacy</a>
+              <a className="block px-3 py-2 hover:bg-prosper-neutral-background" href="/feedback">Send feedback</a>
+              <a className="block px-3 py-2 hover:bg-prosper-neutral-background" href="/contact">Contact us</a>
+              <a className="block px-3 py-2 hover:bg-prosper-neutral-background" href="/terms" target="_blank" rel="noreferrer">Terms</a>
+              <a className="block px-3 py-2 hover:bg-prosper-neutral-background" href="/privacy" target="_blank" rel="noreferrer">Privacy</a>
           </div>
-          <div className="px-3 py-2 border-t flex items-center justify-between">
-            <div className="text-[11px] text-gray-500 truncate">ID: {householdId?.slice(0, 6)}…</div>
-            <button className="text-xs px-2 py-1 rounded border bg-white hover:bg-gray-50" onClick={copyHouseholdId}>Copy</button>
+          <div className="px-3 py-2 border-t border-prosper-neutral-divider flex items-center justify-between">
+            <div className="text-[11px] text-prosper-neutral-text truncate">ID: {householdId?.slice(0, 6)}…</div>
+            <button className="text-xs px-2 py-1 rounded border border-prosper-neutral-divider bg-white hover:bg-prosper-neutral-background" onClick={copyHouseholdId}>Copy</button>
           </div>
         </div>
       )}
 
       {showEdit && (
         <div className="fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4" onClick={() => setShowEdit(false)}>
-          <div className="bg-white rounded-lg border shadow-lg w-full max-w-sm p-4" onClick={(e) => e.stopPropagation()}>
-            <div className="text-sm font-medium text-gray-900 mb-2">Edit profile</div>
-            <label className="block text-xs text-gray-600">Full name</label>
-            <input className="w-full border rounded px-3 py-2 text-sm mb-2" value={fullName} onChange={(e) => setFullName(e.target.value)} placeholder="Your name" />
-            <label className="block text-xs text-gray-600">Email</label>
-            <input className="w-full border rounded px-3 py-2 text-sm" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="name@example.com" />
+          <div className="bg-prosper-neutral-background rounded-lg border border-prosper-neutral-divider shadow-lg w-full max-w-sm p-4" onClick={(e) => e.stopPropagation()}>
+            <div className="text-sm font-medium text-prosper-neutral-dark-ink mb-2">Edit profile</div>
+            <label className="block text-xs text-prosper-neutral-text">Full name</label>
+            <input className="w-full border border-prosper-neutral-divider rounded px-3 py-2 text-sm mb-2" value={fullName} onChange={(e) => setFullName(e.target.value)} placeholder="Your name" />
+            <label className="block text-xs text-prosper-neutral-text">Email</label>
+            <input className="w-full border border-prosper-neutral-divider rounded px-3 py-2 text-sm" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="name@example.com" />
             <div className="mt-3 flex justify-end gap-2">
-              <button className="text-xs px-3 py-1.5 rounded border bg-white hover:bg-gray-50" onClick={() => setShowEdit(false)}>Cancel</button>
-              <button className="text-xs px-3 py-1.5 rounded border bg-gray-900 text-white hover:bg-gray-800" onClick={saveProfile}>Save</button>
+              <button className="text-xs px-3 py-1.5 rounded border border-prosper-neutral-divider bg-white hover:bg-prosper-neutral-background" onClick={() => setShowEdit(false)}>Cancel</button>
+              <button className="text-xs px-3 py-1.5 rounded border border-prosper-green-main bg-prosper-green-main text-white hover:bg-prosper-green-dark" onClick={saveProfile}>Save</button>
             </div>
           </div>
         </div>

--- a/src/app/agentConfigs/chatSupervisor/supervisorAgent.ts
+++ b/src/app/agentConfigs/chatSupervisor/supervisorAgent.ts
@@ -182,7 +182,7 @@ async function handleToolCalls(
       let args: any = {};
       try {
         args = toolCall.arguments ? JSON.parse(toolCall.arguments) : {};
-      } catch (_e) {
+      } catch {
         if (addBreadcrumb) addBreadcrumb(`[supervisorAgent] bad tool args for ${fName}`, { raw: toolCall.arguments });
         args = {};
       }

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -97,9 +97,9 @@ function Sparkline({ points }: { points: SeriesPoint[] }) {
 
   if (!d) {
     return (
-      <div className="h-20 w-full bg-white rounded-md border flex items-center justify-center text-xs text-gray-500">
+      <div className="h-20 w-full bg-prosper-neutral-background rounded-md border border-prosper-neutral-divider flex items-center justify-center text-xs text-prosper-neutral-text">
         <div className="inline-flex items-center gap-2">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="9" stroke="#9CA3AF" /></svg>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="12" cy="12" r="9" stroke="#dadada" /></svg>
           No data
         </div>
       </div>
@@ -262,7 +262,8 @@ export default function Dashboard() {
   const componentsLiabsPresent = (slotsAny?.mortgage_balance?.value != null) || (slotsAny?.other_debt_balances_total?.value != null);
   const assetsOverrideUsed = (slotsAny?.assets_total?.value != null) && !componentsAssetsPresent;
   const debtsOverrideUsed = (slotsAny?.debts_total?.value != null) && !componentsLiabsPresent;
-  // const hasNwOverrides = assetsOverrideUsed || debtsOverrideUsed; // presently unused
+  void assetsOverrideUsed;
+  void debtsOverrideUsed;
 
   return (
     <>
@@ -1169,10 +1170,10 @@ function RangeNetWorth({ series, latest, currency }: { series: SeriesPoint[]; la
 
       {breakdown && (breakdown.assets != null || breakdown.debts != null) && (
         <div className="mt-3">
-          <div className="text-[11px] text-gray-600 mb-1">Assets vs liabilities</div>
+          <div className="text-[11px] text-prosper-neutral-text mb-1">Assets vs liabilities</div>
           {/* Stacked bar: red portion shows liabilities as a share of assets; green is equity portion. */}
           {typeof breakdown.assets === 'number' && breakdown.assets > 0 ? (
-            <div className="w-full h-4 rounded bg-gray-200 overflow-hidden" aria-label="Assets and liabilities breakdown">
+            <div className="w-full h-4 rounded bg-prosper-neutral-divider overflow-hidden" aria-label="Assets and liabilities breakdown">
               {(() => {
                 const assets = breakdown.assets as number;
                 const debts = Math.max(0, (breakdown.debts as number) || 0);
@@ -1180,14 +1181,14 @@ function RangeNetWorth({ series, latest, currency }: { series: SeriesPoint[]; la
                 const equityPct = Math.max(0, 1 - debtPct);
                 return (
                   <div className="w-full h-full flex">
-                    <div className="h-full" style={{ width: `${Math.round(debtPct * 100)}%`, backgroundColor: '#ef4444' }} title={`Liabilities: ${fmtCurrency(debts, currency)}`} />
-                    <div className="h-full" style={{ width: `${Math.round(equityPct * 100)}%`, backgroundColor: '#10b981' }} title={`Equity: ${fmtCurrency(Math.max(assets - debts, 0), currency)}`} />
+                    <div className="h-full" style={{ width: `${Math.round(debtPct * 100)}%`, backgroundColor: '#d9543f' }} title={`Liabilities: ${fmtCurrency(debts, currency)}`} />
+                    <div className="h-full" style={{ width: `${Math.round(equityPct * 100)}%`, backgroundColor: '#3fa46a' }} title={`Equity: ${fmtCurrency(Math.max(assets - debts, 0), currency)}`} />
                   </div>
                 );
               })()}
             </div>
           ) : (
-            <div className="text-[11px] text-gray-500">Add assets and debts to see a breakdown.</div>
+            <div className="text-[11px] text-prosper-neutral-text">Add assets and debts to see a breakdown.</div>
           )}
           <div className="mt-1 text-[11px] text-gray-700 flex items-center gap-3">
             <span>Assets: <b>{typeof breakdown.assets === 'number' ? fmtCurrency(breakdown.assets, currency) : '—'}</b></span>

--- a/src/app/components/Events.tsx
+++ b/src/app/components/Events.tsx
@@ -15,9 +15,9 @@ function Events({ isExpanded }: EventsProps) {
   const { loggedEvents, toggleExpand } = useEvent();
 
   const getDirectionArrow = (direction: string) => {
-    if (direction === "client") return { symbol: "▲", color: "#7f5af0" };
-    if (direction === "server") return { symbol: "▼", color: "#2cb67d" };
-    return { symbol: "•", color: "#555" };
+    if (direction === "client") return { symbol: "▲", color: "#3aa6a3" };
+    if (direction === "server") return { symbol: "▼", color: "#3fa46a" };
+    return { symbol: "•", color: "#666666" };
   };
 
   useEffect(() => {
@@ -35,14 +35,14 @@ function Events({ isExpanded }: EventsProps) {
     <div
       className={
         (isExpanded ? "w-1/2 overflow-auto" : "w-0 overflow-hidden opacity-0") +
-        " transition-all rounded-xl duration-200 ease-in-out flex-col bg-white"
+        " transition-all rounded-xl duration-200 ease-in-out flex-col bg-prosper-neutral-background"
       }
       ref={eventLogsContainerRef}
     >
       {isExpanded && (
         <div>
-          <div className="flex items-center justify-between px-6 py-3.5 sticky top-0 z-10 text-base border-b bg-white rounded-t-xl">
-            <span className="font-semibold">Logs</span>
+          <div className="flex items-center justify-between px-6 py-3.5 sticky top-0 z-10 text-base border-b border-prosper-neutral-divider bg-prosper-neutral-background rounded-t-xl">
+            <span className="font-semibold text-prosper-neutral-dark-ink">Logs</span>
           </div>
           <div>
             {loggedEvents.map((log, idx) => {
@@ -54,7 +54,7 @@ function Events({ isExpanded }: EventsProps) {
               return (
                 <div
                   key={`${log.id}-${idx}`}
-                  className="border-t border-gray-200 py-2 px-6 font-mono"
+                  className="border-t border-prosper-neutral-divider py-2 px-6 font-mono"
                 >
                   <div
                     onClick={() => toggleExpand(log.id)}
@@ -70,20 +70,20 @@ function Events({ isExpanded }: EventsProps) {
                       <span
                         className={
                           "flex-1 text-sm " +
-                          (isError ? "text-red-600" : "text-gray-800")
+                          (isError ? "text-prosper-semantic-error" : "text-prosper-neutral-dark-ink")
                         }
                       >
                         {log.eventName}
                       </span>
                     </div>
-                    <div className="text-gray-500 ml-1 text-xs whitespace-nowrap">
+                    <div className="text-prosper-neutral-text ml-1 text-xs whitespace-nowrap">
                       {log.timestamp}
                     </div>
                   </div>
 
                   {log.expanded && log.eventData && (
-                    <div className="text-gray-800 text-left">
-                      <pre className="border-l-2 ml-1 border-gray-200 whitespace-pre-wrap break-words font-mono text-xs mb-2 mt-2 pl-2">
+                    <div className="text-prosper-neutral-dark-ink text-left">
+                      <pre className="border-l-2 ml-1 border-prosper-neutral-divider whitespace-pre-wrap break-words font-mono text-xs mb-2 mt-2 pl-2">
                         {JSON.stringify(log.eventData, null, 2)}
                       </pre>
                     </div>

--- a/src/app/components/LeftPaneControls.tsx
+++ b/src/app/components/LeftPaneControls.tsx
@@ -42,17 +42,17 @@ export default function LeftPaneControls({
 
   return (
     <div className="sticky top-0 z-10">
-      <div className="backdrop-blur bg-white/80 border rounded-xl px-3 py-2 shadow-sm">
+      <div className="backdrop-blur bg-prosper-neutral-background/80 border border-prosper-neutral-divider rounded-xl px-3 py-2 shadow-sm">
         <div className="flex flex-wrap items-center gap-3">
           <button
             onClick={onToggleConnection}
             disabled={isConnecting}
-            className={`px-3 h-9 rounded-lg text-sm font-medium shadow-sm border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            className={`px-3 h-9 rounded-lg text-sm font-medium shadow-sm border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-prosper-neutral-background ${
               isConnected
-                ? "bg-red-600 text-white border-red-600 hover:bg-red-700 focus:ring-red-300"
+                ? "bg-prosper-semantic-error text-white border-prosper-semantic-error hover:bg-prosper-semantic-error/90 focus:ring-prosper-semantic-error/40"
                 : isConnecting
-                ? "bg-gray-300 text-gray-700 border-gray-300 cursor-wait"
-                : "bg-gray-900 text-white border-gray-900 hover:bg-gray-800 focus:ring-gray-300"
+                ? "bg-prosper-neutral-divider text-prosper-neutral-text border-prosper-neutral-divider cursor-wait"
+                : "bg-prosper-green-main text-white border-prosper-green-main hover:bg-prosper-green-dark focus:ring-prosper-green-light"
             }`}
             aria-pressed={isConnected}
           >
@@ -60,7 +60,7 @@ export default function LeftPaneControls({
           </button>
 
           {/* PTT toggle + hold-to-talk */}
-          <label className="inline-flex items-center gap-2 text-sm select-none">
+          <label className="inline-flex items-center gap-2 text-sm select-none text-prosper-neutral-text">
             <input
               type="checkbox"
               className="h-4 w-4 rounded"
@@ -81,17 +81,17 @@ export default function LeftPaneControls({
             aria-label="Hold to talk"
             className={`h-9 px-3 rounded-lg border text-sm transition-colors ${
               !isConnected || !isPTTActive
-                ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                ? "bg-prosper-neutral-background text-prosper-neutral-divider cursor-not-allowed border-prosper-neutral-divider"
                 : isPTTUserSpeaking
-                ? "bg-gray-200"
-                : "bg-white hover:bg-gray-50"
+                ? "bg-prosper-neutral-divider border-prosper-neutral-divider"
+                : "bg-white hover:bg-prosper-neutral-background border-prosper-neutral-divider"
             }`}
           >
             {isPTTUserSpeaking ? "Release to send" : "Talk"}
           </button>
 
           {/* Audio playback */}
-          <label className="inline-flex items-center gap-2 text-sm select-none">
+          <label className="inline-flex items-center gap-2 text-sm select-none text-prosper-neutral-text">
             <input
               type="checkbox"
               className="h-4 w-4 rounded"
@@ -104,10 +104,10 @@ export default function LeftPaneControls({
 
           {/* Codec selector */}
           <div className="ml-auto inline-flex items-center gap-2 text-sm">
-            <label htmlFor="codec-select" className="text-gray-600">Codec</label>
+            <label htmlFor="codec-select" className="text-prosper-neutral-text">Codec</label>
             <select
               id="codec-select"
-              className="h-9 rounded-lg border bg-white px-2 text-sm"
+              className="h-9 rounded-lg border border-prosper-neutral-divider bg-white px-2 text-sm"
               value={codec}
               onChange={(e) => onCodecChange(e.target.value)}
             >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,15 +3,22 @@
 @tailwind utilities;
 
 :root {
-  --background: #fafafa;
-  --foreground: #171717;
-}
+  --prosper-green-main: #3fa46a;
+  --prosper-green-dark: #2f7d52;
+  --prosper-green-light: #d7f2e3;
+  --prosper-accent-gold: #d9b648;
+  --prosper-accent-teal: #3aa6a3;
+  --prosper-neutral-dark-ink: #2b2b2c;
+  --prosper-neutral-text: #666666;
+  --prosper-neutral-background: #f3f3f4;
+  --prosper-neutral-divider: #dadada;
+  --prosper-semantic-success: #4caf50;
+  --prosper-semantic-warning: #e0a63a;
+  --prosper-semantic-error: #d9543f;
+  --prosper-semantic-info: #3f7fd9;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: var(--prosper-neutral-background);
+  --foreground: var(--prosper-neutral-dark-ink);
 }
 
 body {

--- a/src/app/lib/prosperTools.ts
+++ b/src/app/lib/prosperTools.ts
@@ -133,7 +133,7 @@ export function assignProsperLevels(kpis: KPIs) {
 }
 
 /** Produce a small, prioritised action plan from KPIs & levels. */
-export function generateRecommendations(kpis: KPIs, levels: any, _preferences: Record<string, any> = {}) {
+export function generateRecommendations(kpis: KPIs, levels: any) {
   const recs: any[] = [];
   const gating = levels?.gating_pillar ?? "spend";
 

--- a/src/app/lib/recommendationsV2.ts
+++ b/src/app/lib/recommendationsV2.ts
@@ -138,5 +138,5 @@ export function generateTwoBestActions(k: KpisV2, g: GatesV2): Array<{ title: st
     .map(a => ({ ...a, score: a.score ?? 0.5 }))
     .sort((a, b) => (b.score! - a.score!));
 
-  return ranked.slice(0, 2).map((a) => { const { score: _omit, ...rest } = a; return rest; });
+  return ranked.slice(0, 2).map((a) => { const { score, ...rest } = a; void score; return rest; });
 }

--- a/src/app/share/benchmarks/opengraph-image.tsx
+++ b/src/app/share/benchmarks/opengraph-image.tsx
@@ -20,15 +20,15 @@ export default function Image({ searchParams }: { searchParams: Record<string, s
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'linear-gradient(135deg, #ecfdf5 0%, #ffffff 80%)',
+          background: 'linear-gradient(135deg, #d7f2e3 0%, #ffffff 80%)',
           fontFamily: 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial',
         }}
       >
         <div style={{ width: '100%', height: '100%', padding: 40, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ fontSize: 28, color: '#065f46', border: '2px solid #065f46', borderRadius: 999, padding: '8px 18px' }}>Prosper • People like you</div>
-          <div style={{ marginTop: 16, fontSize: 96, fontWeight: 800, color: '#111827' }}>Top {top ?? '—'}% of peers</div>
-          <div style={{ marginTop: 8, fontSize: 32, color: '#4b5563' }}>{label}</div>
-          <div style={{ position: 'absolute', bottom: 40, fontSize: 28, color: '#6b7280' }}>Made with Prosper — your personal wealth coach</div>
+          <div style={{ fontSize: 28, color: '#2f7d52', border: '2px solid #2f7d52', borderRadius: 999, padding: '8px 18px' }}>Prosper • People like you</div>
+          <div style={{ marginTop: 16, fontSize: 96, fontWeight: 800, color: '#2b2b2c' }}>Top {top ?? '—'}% of peers</div>
+          <div style={{ marginTop: 8, fontSize: 32, color: '#666666' }}>{label}</div>
+          <div style={{ position: 'absolute', bottom: 40, fontSize: 28, color: '#666666' }}>Made with Prosper — your personal wealth coach</div>
         </div>
       </div>
     ),

--- a/src/app/share/benchmarks/twitter-image.tsx
+++ b/src/app/share/benchmarks/twitter-image.tsx
@@ -20,14 +20,14 @@ export default function Image({ searchParams }: { searchParams: Record<string, s
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'linear-gradient(135deg, #ecfdf5 0%, #ffffff 80%)',
+          background: 'linear-gradient(135deg, #d7f2e3 0%, #ffffff 80%)',
           fontFamily: 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial',
         }}
       >
         <div style={{ width: '100%', height: '100%', padding: 32, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ fontSize: 22, color: '#065f46', border: '2px solid #065f46', borderRadius: 999, padding: '6px 14px' }}>Prosper • People like you</div>
-          <div style={{ marginTop: 12, fontSize: 72, fontWeight: 800, color: '#111827' }}>Top {top ?? '—'}% of peers</div>
-          <div style={{ marginTop: 6, fontSize: 24, color: '#4b5563' }}>{label}</div>
+          <div style={{ fontSize: 22, color: '#2f7d52', border: '2px solid #2f7d52', borderRadius: 999, padding: '6px 14px' }}>Prosper • People like you</div>
+          <div style={{ marginTop: 12, fontSize: 72, fontWeight: 800, color: '#2b2b2c' }}>Top {top ?? '—'}% of peers</div>
+          <div style={{ marginTop: 6, fontSize: 24, color: '#666666' }}>{label}</div>
         </div>
       </div>
     ),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,29 @@ export default {
   theme: {
     extend: {
       colors: {
+        prosper: {
+          green: {
+            main: "var(--prosper-green-main)",
+            dark: "var(--prosper-green-dark)",
+            light: "var(--prosper-green-light)",
+          },
+          accent: {
+            gold: "var(--prosper-accent-gold)",
+            teal: "var(--prosper-accent-teal)",
+          },
+          neutral: {
+            "dark-ink": "var(--prosper-neutral-dark-ink)",
+            text: "var(--prosper-neutral-text)",
+            background: "var(--prosper-neutral-background)",
+            divider: "var(--prosper-neutral-divider)",
+          },
+          semantic: {
+            success: "var(--prosper-semantic-success)",
+            warning: "var(--prosper-semantic-warning)",
+            error: "var(--prosper-semantic-error)",
+            info: "var(--prosper-semantic-info)",
+          },
+        },
         background: "var(--background)",
         foreground: "var(--foreground)",
       },


### PR DESCRIPTION
## Summary
- define Prosper color variables and expose them through Tailwind theme
- restyle core UI components to use brand palette
- update share images and clean lint warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbf08b8bb48326ad98d59e94beceb0