### PR TITLE
feat: elevate waitlist hero

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -18,12 +18,7 @@ function Footer() {
           <Link href="/terms" className="hover:text-fg">Terms</Link>
           <Link href="/contact" className="hover:text-fg">Contact</Link>
         </div>
-        <div className="flex items-center gap-3">
-          <a href="https://x.com/" className="hover:text-fg">X</a>
-          <a href="https://instagram.com/" className="hover:text-fg" aria-label="Instagram">
-            <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm border border-current text-xs">IG</span>
-          </a>
-        </div>
+        <p className="text-xs text-dim/80 sm:text-sm">© {new Date().getFullYear()} Prosper</p>
       </div>
     </footer>
   )
@@ -58,21 +53,44 @@ export default function Page() {
 
       {/* Nav hidden */}
 
-      <section className="relative z-20 flex h-full items-center justify-center">
-        <div className="w-full max-w-[1120px] px-6">
-          <div className="flex flex-col items-center text-center gap-6 md:gap-8">
-            <h1 className="text-4xl font-semibold tracking-tight md:text-6xl md:leading-tight">
-              Your personal money coach
-            </h1>
-            <p className="text-dim text-lg md:text-xl md:text-balance max-w-[680px]">
-              A step-by-step plan to grow your wealth
-            </p>
-            <div className="flex w-full max-w-[520px] flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-              <WaitlistForm includeName={false} buttonLabel="Join Waitlist" placeholder="Enter your email" />
+      <section className="relative z-20 flex h-full items-center justify-center px-6">
+        <div className="relative w-full max-w-[1120px]">
+          <div className="pointer-events-none absolute inset-0 rounded-[36px] border border-white/10 bg-gradient-to-br from-white/8 via-white/4 to-white/0 opacity-70 blur-xl" />
+          <div className="relative mx-auto flex w-full max-w-[720px] flex-col items-center gap-8 rounded-[32px] border border-white/15 bg-black/55 px-8 py-12 text-center shadow-[0_30px_90px_-35px_rgba(0,0,0,0.6)] backdrop-blur-xl sm:px-12">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-1 text-xs uppercase tracking-[0.22em] text-white/70">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" aria-hidden />
+              Private waitlist now open
             </div>
-            <p className="text-xs text-dim md:text-sm">
-              Join the waitlist for early access
-            </p>
+            <div className="flex flex-col gap-5 md:gap-6">
+              <h1 className="text-4xl font-semibold tracking-tight md:text-[56px] md:leading-[1.05]">
+                Wealth coaching that keeps you moving forward every week
+              </h1>
+              <p className="mx-auto max-w-[640px] text-balance text-base text-white/80 md:text-lg">
+                Prosper’s human coach audits your accounts, builds a roadmap tailored to your goals, and checks in every seven days so the next best money move is always clear.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-white/75 md:text-base">
+              <span className="rounded-full border border-white/20 bg-white/5 px-4 py-2 font-medium">
+                First plan delivered within 5 business days
+              </span>
+              <span className="rounded-full border border-white/20 bg-white/5 px-4 py-2 font-medium">
+                Weekly accountability + progress reports
+              </span>
+              <span className="rounded-full border border-white/20 bg-white/5 px-4 py-2 font-medium">
+                Founding members keep concierge pricing
+              </span>
+            </div>
+            <div className="flex w-full max-w-[520px] flex-col gap-4">
+              <WaitlistForm includeName={true} buttonLabel="Join the Waitlist" placeholder="Your best email" />
+              <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-xs text-white/70 sm:text-sm">
+                <p className="font-medium text-white/80">What to expect next</p>
+                <ul className="space-y-1 leading-relaxed">
+                  <li>• A confirmation note with the Prosper launch preview.</li>
+                  <li>• Early-access scheduling once your cohort opens.</li>
+                  <li>• No spam — unsubscribe anytime in one click.</li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- restyle the waitlist hero into a glassmorphism card with elevated premium framing and supporting badge
- refresh the headline, subcopy, and proof chips to clarify Prosper’s human coaching cadence and founding-member offer
- add a short post-form checklist that sets expectations and reinforces trust while socials remain hidden

## Testing
- `npm run lint` *(fails: existing lint violations throughout unrelated files in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d4a8d8b08326ac32bef5eed072bc